### PR TITLE
Update documentation links

### DIFF
--- a/0_dashboards/README.md
+++ b/0_dashboards/README.md
@@ -6,7 +6,7 @@ Dashboard Panels must reside in a `dashboard` directory, but can be named anythi
 
 Each Dashboard Panel must be identified in the `package.json` using the following `nodecg` schema. The key point to note here is that the `file` specifies a path to the dashboard panel relative to the `dashboard` directory.
 
-For more information, see http://nodecg.com/tutorial-manifest.html
+For more information, see https://nodecg.com/docs/manifest
 
 ```json
 "nodecg": {
@@ -27,7 +27,7 @@ Note that `dashboardPanels` is an array, meaning that you can specify multiple p
 
 ## Replicants
 
-http://nodecg.com/NodeCG.html#Replicant
+https://nodecg.com/docs/classes/replicant
 
 Replicants allow for the passing of values throughout NodeCG and, in my experience, will be your most commonly used aspect of NodeCG.
 

--- a/1_graphics/README.md
+++ b/1_graphics/README.md
@@ -6,7 +6,7 @@ Graphics must reside in a `graphics` directory, but can be named anything.
 
 Each Graphic must be identified in the `package.json` using the following `nodecg` schema. The key point to note here is that the `file` specifies a path to the graphic relative to the `graphics` directory.
 
-For more information, see http://nodecg.com/tutorial-manifest.html
+For more information, see https://nodecg.com/docs/manifest
 
 ```json
 "nodecg": {

--- a/2_extensions/README.md
+++ b/2_extensions/README.md
@@ -24,7 +24,7 @@ module.exports = nodecg => {
 }
 ```
 
-For more information, see http://nodecg.com/index.html#extensions
+For more information, see https://nodecg.com/docs/concepts-and-terminology#extensions
 
 ## Example
 


### PR DESCRIPTION
This updates the documentation links which no longer exist on the nodecg.com website to point to the current versions.