### PR TITLE
Deprecate Simple Examples Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# NodeCG Simple Examples
+# NodeCG Simple Example (DEPRECATED)
+
+❌ ❌ ❌
+
+This repository is build off of an older version of NodeCG and should no longer be used as a default example. Working with NodeCG 2.0 and above will provide a better overall experience.
+
+❌ ❌ ❌
+
+## NodeCG Simple Examples
 
 To run these examples using your local instance of NodeCG, copy each of the three directories into your `nodecg/bundles` directory.
 


### PR DESCRIPTION
This repository hasn't been updated in three years and should be marked as Archived on GitHub. This just adds a marker into the README to correspond with a GitHub administration message.